### PR TITLE
Set fixed video directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChrisFlix
 
-Simple video browser that serves files from a directory defined by the `VIDEO_DIR` environment variable.
+Simple video browser that serves files from the directory `F:\Films\`.
 
 ## Backend
 
@@ -8,7 +8,7 @@ Run the backend with Flask:
 
 ```bash
 pip install -r backend/requirements.txt
-VIDEO_DIR=/path/to/videos python backend/server.py
+python backend/server.py
 ```
 
 ## Frontend

--- a/backend/server.py
+++ b/backend/server.py
@@ -3,7 +3,10 @@ import mimetypes
 from pathlib import Path
 from flask import Flask, jsonify, send_from_directory, abort, request, Response
 
-VIDEO_DIR = os.environ.get("VIDEO_DIR", "videos")
+# Directory containing the video files. Previously configurable via the
+# `VIDEO_DIR` environment variable, this path is now fixed to match the
+# requested setup.
+VIDEO_DIR = "F:\\Films\\"
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
 


### PR DESCRIPTION
## Summary
- use a fixed `VIDEO_DIR` path instead of an environment variable
- update README instructions for the new path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684456f4db60832f964e20f4552fb773