### PR TITLE
Fix API path and enhance code clarity

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,7 +1,15 @@
 let currentPath = "";
 
+function encodePath(path) {
+    return path.split("/").map(encodeURIComponent).join("/");
+}
+
+function apiListUrl(path) {
+    return path ? `/api/list/${encodePath(path)}` : "/api/list";
+}
+
 function load(path = "") {
-    fetch(`/api/list/${path}`)
+    fetch(apiListUrl(path))
         .then(response => {
             if (!response.ok) {
                 throw new Error("Failed to load directory");
@@ -41,7 +49,8 @@ function goBack() {
 function playVideo(path) {
     const player = document.getElementById('player');
     const video = document.getElementById('video');
-    video.src = `/api/video/${path}`;
+    const encoded = encodePath(path);
+    video.src = `/api/video/${encoded}`;
     player.style.display = 'block';
     video.play();
 }


### PR DESCRIPTION
## Summary
- enhance API URL handling on the frontend
- URL-encode paths when requesting the backend
- add docstrings and formatting to the Flask server

## Testing
- `python -m py_compile backend/server.py`

------
https://chatgpt.com/codex/tasks/task_e_68445b71e708832f94c5706b549531a7