### PR TITLE
Add AVI transcoding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Set the `VIDEO_DIR` environment variable to override the default Windows path
 `F:\Films\` used in the original setup.
 
 Supported video formats include **MP4**, **MKV**, **AVI**, and **MOV**.
-Most browsers do not natively play Matroska files. When `ffmpeg` is available on
-the system, the server can transcode `.mkv` files to MP4 on the fly so they play
+Most browsers do not natively play Matroska or AVI files. When `ffmpeg` is available on
+the system, the server can transcode `.mkv` and `.avi` files to MP4 on the fly so they play
 in the browser.
 
 For transcoding to work you must have the **ffmpeg** executable installed and

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -60,7 +60,7 @@ function playVideo(path) {
     };
     let mime = mimeMap[ext] || '';
     source.type = mime;
-    if (mime && !video.canPlayType(mime) && ext === 'mkv') {
+    if (mime && !video.canPlayType(mime) && (ext === 'mkv' || ext === 'avi')) {
         source.src = `/api/transcode/${encoded}`;
         source.type = 'video/mp4';
     } else {


### PR DESCRIPTION
## Summary
- transcode AVI files when the browser does not support `video/x-msvideo`
- document AVI transcoding support

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_684467116244832f8c2a943d60c16851