### PR TITLE
Add thumbnails, search, and comments

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,10 +10,14 @@
     <header>
         <h1>ChrisFlix</h1>
     </header>
+    <div class="search">
+        <input type="text" id="search-input" placeholder="Search movies" />
+        <button onclick="searchVideos()">Search</button>
+    </div>
     <main id="browser">
         <div id="path"></div>
         <button id="back" onclick="goBack()" style="display:none">Back</button>
-        <ul id="items"></ul>
+        <div id="items" class="items-grid"></div>
     </main>
     <div id="player" style="display:none">
         <video id="video" controls width="640">
@@ -21,6 +25,22 @@
             Your browser does not support HTML5 video.
         </video>
         <button id="close" onclick="closePlayer()">Close</button>
+        <div id="comments">
+            <h2>Comments</h2>
+            <ul id="comment-list"></ul>
+            <form id="comment-form" onsubmit="submitComment(event)">
+                <input type="text" id="username" placeholder="Name" required />
+                <select id="rating">
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                </select>
+                <textarea id="comment-text" placeholder="Your comment" required></textarea>
+                <button type="submit">Post</button>
+            </form>
+        </div>
     </div>
     <script src="app.js"></script>
 </body>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -17,6 +17,11 @@ header {
     background: #000;
 }
 
+.search {
+    text-align: center;
+    margin: 20px;
+}
+
 h1 {
     margin: 0;
     color: var(--accent-color);
@@ -46,24 +51,69 @@ button:hover {
     background: #1ed760;
 }
 
-ul {
-    list-style: none;
-    padding: 0;
+
+.items-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
 }
 
-li {
+.tile {
+    width: 150px;
+    cursor: pointer;
+}
+
+.tile img {
+    width: 100%;
+    display: block;
+    border-radius: 4px;
+}
+
+.tile .title {
+    text-align: center;
+    margin-top: 5px;
+}
+
+.dir {
     padding: 10px;
     cursor: pointer;
     border-bottom: 1px solid #333;
 }
 
-li:hover {
+.dir:hover {
     background: #333;
 }
 
 #player {
     margin: 20px;
     text-align: center;
+}
+
+#comments {
+    max-width: 640px;
+    margin: 0 auto;
+    text-align: left;
+}
+
+#comment-list {
+    list-style: none;
+    padding: 0;
+}
+
+#comment-list li {
+    border-bottom: 1px solid #333;
+    padding: 5px 0;
+}
+
+#comment-form {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+#comment-form textarea {
+    min-height: 60px;
 }
 
 video {


### PR DESCRIPTION
## Summary
- implement SQLite database and comment API in backend
- support search and thumbnail generation with ffmpeg/ffprobe
- create search UI with clickable video tiles
- show comments and allow posting from frontend
- update styles for a Netflix-like green theme

## Testing
- `python -m py_compile backend/server.py`

------
https://chatgpt.com/codex/tasks/task_e_68446f71ad5c832fac9914e2ae580552