### PR TITLE
Adjust logo size and comment behavior

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ChrisFlix</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" href="acceuil-logo.png">
+    <link rel="icon" type="image/png" sizes="64x64" href="acceuil-logo.png">
 </head>
 <body>
     <canvas id="matrix"></canvas>

--- a/frontend/matrix.js
+++ b/frontend/matrix.js
@@ -9,6 +9,8 @@ window.addEventListener('load', () => {
     let columns = Math.floor(width / fontSize);
     const drops = new Array(columns).fill(1);
     let currentComment = null;
+    let commentExpire = 0;
+    const commentDuration = 5000; // display each comment for 5 seconds
 
     function fetchRandomComment() {
         fetch('/api/random_comment')
@@ -17,13 +19,14 @@ window.addEventListener('load', () => {
                 if (data && data.comment) {
                     const name = data.video.split('/').pop();
                     currentComment = `${name}-${data.rating}/5-${data.comment}`;
+                    commentExpire = Date.now() + commentDuration;
                 }
             })
             .catch(() => {});
     }
 
     fetchRandomComment();
-    setInterval(fetchRandomComment, 10000);
+    setInterval(fetchRandomComment, 5000);
 
     function resize() {
         width = canvas.width = window.innerWidth;
@@ -54,10 +57,14 @@ window.addEventListener('load', () => {
         }
 
         if (currentComment) {
-            ctx.fillStyle = '#ff0';
-            const x = Math.random() * (width - currentComment.length * fontSize);
-            const y = Math.random() * height;
-            ctx.fillText(currentComment, x, y);
+            if (Date.now() > commentExpire) {
+                currentComment = null;
+            } else {
+                ctx.fillStyle = '#ff0';
+                const x = Math.random() * (width - currentComment.length * fontSize);
+                const y = Math.random() * height;
+                ctx.fillText(currentComment, x, y);
+            }
         }
     }
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -34,7 +34,7 @@ h1 {
 }
 
 #logo {
-    width: 50px;
+    width: 80px;
     height: auto;
 }
 


### PR DESCRIPTION
## Summary
- bump favicon size to 64x64 and enlarge header logo
- show one random comment every 5 seconds and display it longer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68448ad718f0832fb09eb0cc3f5b6842