### PR TITLE
Update UI and comment display

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -24,11 +24,8 @@ function load(path = "") {
             const list = document.getElementById("items");
             list.innerHTML = '';
             data.directories.forEach(dir => {
-                const div = document.createElement('div');
-                div.className = 'dir';
-                div.textContent = dir + '/';
-                div.onclick = () => load(currentPath ? `${currentPath}/${dir}` : dir);
-                list.appendChild(div);
+                const tile = createDirectoryTile(dir);
+                list.appendChild(tile);
             });
             data.files.forEach(file => {
                 const fullPath = currentPath ? `${currentPath}/${file}` : file;
@@ -59,6 +56,21 @@ function createVideoTile(name, fullPath) {
     div.appendChild(img);
     div.appendChild(title);
     div.onclick = () => playVideo(fullPath);
+    return div;
+}
+
+function createDirectoryTile(name) {
+    const div = document.createElement('div');
+    div.className = 'tile dir-tile';
+    const img = document.createElement('img');
+    img.src = 'Dossier Vert.png';
+    img.alt = name;
+    const title = document.createElement('div');
+    title.className = 'title';
+    title.textContent = name + '/';
+    div.appendChild(img);
+    div.appendChild(title);
+    div.onclick = () => load(currentPath ? `${currentPath}/${name}` : name);
     return div;
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ChrisFlix</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" type="image/png" sizes="64x64" href="acceuil-logo.png">
+    <link rel="icon" type="image/x-icon" href="acceuil-logo.ico">
 </head>
 <body>
     <canvas id="matrix"></canvas>

--- a/frontend/matrix.js
+++ b/frontend/matrix.js
@@ -11,6 +11,8 @@ window.addEventListener('load', () => {
     let currentComment = null;
     let commentExpire = 0;
     const commentDuration = 5000; // display each comment for 5 seconds
+    let commentX = 0;
+    let commentY = 0;
 
     function fetchRandomComment() {
         fetch('/api/random_comment')
@@ -20,6 +22,8 @@ window.addEventListener('load', () => {
                     const name = data.video.split('/').pop();
                     currentComment = `${name}-${data.rating}/5-${data.comment}`;
                     commentExpire = Date.now() + commentDuration;
+                    commentX = (width - currentComment.length * fontSize) / 2;
+                    commentY = height - fontSize * 2;
                 }
             })
             .catch(() => {});
@@ -61,9 +65,7 @@ window.addEventListener('load', () => {
                 currentComment = null;
             } else {
                 ctx.fillStyle = '#ff0';
-                const x = Math.random() * (width - currentComment.length * fontSize);
-                const y = Math.random() * height;
-                ctx.fillText(currentComment, x, y);
+                ctx.fillText(currentComment, commentX, commentY);
             }
         }
     }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -34,7 +34,7 @@ h1 {
 }
 
 #logo {
-    width: 80px;
+    width: 240px;
     height: auto;
 }
 
@@ -88,6 +88,13 @@ button:hover {
     text-align: center;
     margin-top: 5px;
     color: var(--accent-color);
+}
+
+.dir-tile img {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto;
+    display: block;
 }
 
 .dir {


### PR DESCRIPTION
## Summary
- use `.ico` favicon
- enlarge homepage logo
- display folder tiles with a green folder image
- show comments at fixed position every 5s

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449856b058832fac350590b37c5ead