### PR TITLE
Enhance navigation and comments

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -23,6 +23,12 @@ function load(path = "") {
             document.getElementById("back").style.display = currentPath ? 'block' : 'none';
             const list = document.getElementById("items");
             list.innerHTML = '';
+            const totalItems = data.directories.length + data.files.length;
+            if (totalItems < 10) {
+                list.classList.add('few-items');
+            } else {
+                list.classList.remove('few-items');
+            }
             data.directories.forEach(dir => {
                 const tile = createDirectoryTile(dir);
                 list.appendChild(tile);
@@ -115,6 +121,7 @@ function playVideo(path) {
     video.load();
     player.style.display = 'block';
     video.play();
+    player.scrollIntoView({ behavior: 'smooth' });
     loadComments(path);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,9 @@
 <body>
     <canvas id="matrix"></canvas>
     <header>
-        <img id="logo" src="acceuil-logo.png" alt="ChrisFlix logo">
+        <button id="logo-button" onclick="load('')">
+            <img src="acceuil-logo.png" alt="ChrisFlix logo">
+        </button>
         <h1>ChrisFlix</h1>
     </header>
     <div class="search">

--- a/frontend/matrix.js
+++ b/frontend/matrix.js
@@ -13,6 +13,15 @@ window.addEventListener('load', () => {
     const commentDuration = 5000; // display each comment for 5 seconds
     let commentX = 0;
     let commentY = 0;
+    let commentColor = '#ff0';
+
+    function randomColor() {
+        let color;
+        do {
+            color = '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
+        } while (color.toLowerCase() === '#00ff00');
+        return color;
+    }
 
     function fetchRandomComment() {
         fetch('/api/random_comment')
@@ -22,8 +31,9 @@ window.addEventListener('load', () => {
                     const name = data.video.split('/').pop();
                     currentComment = `${name}-${data.rating}/5-${data.comment}`;
                     commentExpire = Date.now() + commentDuration;
-                    commentX = (width - currentComment.length * fontSize) / 2;
-                    commentY = height - fontSize * 2;
+                    commentX = Math.random() * (width - currentComment.length * fontSize);
+                    commentY = Math.random() * (height - fontSize);
+                    commentColor = randomColor();
                 }
             })
             .catch(() => {});
@@ -64,7 +74,7 @@ window.addEventListener('load', () => {
             if (Date.now() > commentExpire) {
                 currentComment = null;
             } else {
-                ctx.fillStyle = '#ff0';
+                ctx.fillStyle = commentColor;
                 ctx.fillText(currentComment, commentX, commentY);
             }
         }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -33,9 +33,17 @@ h1 {
     letter-spacing: 2px;
 }
 
-#logo {
+#logo-button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}
+
+#logo-button img {
     width: 240px;
     height: auto;
+    display: block;
 }
 
 #browser {
@@ -68,6 +76,11 @@ button:hover {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
+    justify-content: center;
+}
+
+.items-grid.few-items .tile {
+    width: 200px;
 }
 
 .tile {
@@ -76,6 +89,9 @@ button:hover {
     background: rgba(0, 0, 0, 0.4);
     border-radius: 4px;
     padding: 5px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .tile img {
@@ -88,6 +104,8 @@ button:hover {
     text-align: center;
     margin-top: 5px;
     color: var(--accent-color);
+    width: 100%;
+    word-break: break-word;
 }
 
 .dir-tile img {


### PR DESCRIPTION
## Summary
- swap the header logo for a home button
- center grid layout and enlarge items when few are listed
- keep filenames centered
- scroll to the player when a video starts
- display matrix comments anywhere with random colors

## Testing
- `python3 -m py_compile backend/server.py`
- `node --check frontend/app.js`
- `node --check frontend/matrix.js`


------
https://chatgpt.com/codex/tasks/task_e_6844a740cd98832f98421221a5ba2a82