### PR TITLE
Add username persistence and highlight in comments

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -274,14 +274,21 @@ def video_comments(path: str):
 
 @app.route("/api/random_comment")
 def random_comment():
-    """Return a random comment from the database."""
+    """Return a random comment from the database including the username."""
     conn = get_db()
     row = conn.execute(
-        "SELECT video, comment, rating FROM comments ORDER BY RANDOM() LIMIT 1"
+        "SELECT video, comment, rating, username FROM comments ORDER BY RANDOM() LIMIT 1"
     ).fetchone()
     conn.close()
     if row:
-        return jsonify({"video": row[0], "comment": row[1], "rating": row[2]})
+        return jsonify(
+            {
+                "video": row[0],
+                "comment": row[1],
+                "rating": row[2],
+                "username": row[3],
+            }
+        )
     return jsonify({})
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -149,8 +149,9 @@ function loadComments(path) {
 function submitComment(event) {
     event.preventDefault();
     if (!currentVideo) return;
+    const usernameInput = document.getElementById('username');
     const payload = {
-        username: document.getElementById('username').value,
+        username: usernameInput.value,
         comment: document.getElementById('comment-text').value,
         rating: document.getElementById('rating').value
     };
@@ -159,9 +160,19 @@ function submitComment(event) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
     }).then(() => {
+        localStorage.setItem('username', payload.username);
         document.getElementById('comment-text').value = '';
         loadComments(currentVideo);
     });
 }
 
-window.onload = () => load();
+window.onload = () => {
+    load();
+    const stored = localStorage.getItem('username');
+    if (stored) {
+        document.getElementById('username').value = stored;
+    }
+    document.getElementById('username').addEventListener('change', e => {
+        localStorage.setItem('username', e.target.value);
+    });
+};

--- a/frontend/matrix.js
+++ b/frontend/matrix.js
@@ -9,11 +9,20 @@ window.addEventListener('load', () => {
     let columns = Math.floor(width / fontSize);
     const drops = new Array(columns).fill(1);
     let currentComment = null;
+    let currentUsername = null;
     let commentExpire = 0;
     const commentDuration = 5000; // display each comment for 5 seconds
     let commentX = 0;
     let commentY = 0;
     let commentColor = '#ff0';
+    let nameColor = '#00f';
+
+    function oppositeColor(hex) {
+        const r = 255 - parseInt(hex.substr(1, 2), 16);
+        const g = 255 - parseInt(hex.substr(3, 2), 16);
+        const b = 255 - parseInt(hex.substr(5, 2), 16);
+        return '#' + r.toString(16).padStart(2, '0') + g.toString(16).padStart(2, '0') + b.toString(16).padStart(2, '0');
+    }
 
     function randomColor() {
         let color;
@@ -29,11 +38,13 @@ window.addEventListener('load', () => {
             .then(data => {
                 if (data && data.comment) {
                     const name = data.video.split('/').pop();
+                    currentUsername = data.username || 'Anonymous';
                     currentComment = `${name}-${data.rating}/5-${data.comment}`;
                     commentExpire = Date.now() + commentDuration;
                     commentX = Math.random() * (width - currentComment.length * fontSize);
                     commentY = Math.random() * (height - fontSize);
                     commentColor = randomColor();
+                    nameColor = oppositeColor(commentColor);
                 }
             })
             .catch(() => {});
@@ -73,9 +84,15 @@ window.addEventListener('load', () => {
         if (currentComment) {
             if (Date.now() > commentExpire) {
                 currentComment = null;
+                currentUsername = null;
             } else {
+                ctx.font = fontSize + 'px monospace';
+                ctx.fillStyle = nameColor;
+                const nameText = currentUsername + ':';
+                ctx.fillText(nameText, commentX, commentY);
+                const nameWidth = ctx.measureText(nameText).width;
                 ctx.fillStyle = commentColor;
-                ctx.fillText(currentComment, commentX, commentY);
+                ctx.fillText(currentComment, commentX + nameWidth + fontSize * 0.25, commentY);
             }
         }
     }


### PR DESCRIPTION
## Summary
- save username in browser local storage
- show usernames in the Matrix comment canvas and highlight them with the opposite colour
- extend random comment API to return username

## Testing
- `python -m py_compile backend/server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ab0ffa40832f98318ae9cc8a4fff